### PR TITLE
Add option to customize colors via bottomSheetColor and barrierColor.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:adaptive_action_sheet/adaptive_action_sheet.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 void main() {
   runApp(MyApp());
@@ -34,19 +35,54 @@ class _MyHomePageState extends State<MyHomePage> {
         title: const Text('Adaptive action sheet example'),
       ),
       body: Center(
-        child: RaisedButton(
-          onPressed: () {
-            showAdaptiveActionSheet(
-              context: context,
-              actions: <BottomSheetAction>[
-                BottomSheetAction(title: 'Item 1', onPressed: () {}),
-                BottomSheetAction(title: 'Item 2', onPressed: () {}),
-                BottomSheetAction(title: 'Item 3', onPressed: () {}),
-              ],
-              cancelAction: CancelAction(title: 'Cancel'),
-            );
-          },
-          child: const Text('Show action sheet'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            RaisedButton(
+              onPressed: () {
+                showAdaptiveActionSheet(
+                  context: context,
+                  actions: <BottomSheetAction>[
+                    BottomSheetAction(title: 'Item 1', onPressed: () {}),
+                    BottomSheetAction(title: 'Item 2', onPressed: () {}),
+                    BottomSheetAction(title: 'Item 3', onPressed: () {}),
+                  ],
+                  cancelAction: CancelAction(title: 'Cancel'),
+                );
+              },
+              child: const Text('Show action sheet'),
+            ),
+            RaisedButton(
+              onPressed: () {
+                showAdaptiveActionSheet(
+                  context: context,
+                  bottomSheetColor: Colors.greenAccent,
+                  actions: <BottomSheetAction>[
+                    BottomSheetAction(title: 'Item 1', onPressed: () {}),
+                    BottomSheetAction(title: 'Item 2', onPressed: () {}),
+                    BottomSheetAction(title: 'Item 3', onPressed: () {}),
+                  ],
+                  cancelAction: CancelAction(title: 'Cancel'),
+                );
+              },
+              child: const Text('Show action sheet with custom sheet color'),
+            ),
+            RaisedButton(
+              onPressed: () {
+                showAdaptiveActionSheet(
+                  context: context,
+                  barrierColor: Colors.greenAccent[200].withOpacity(0.5),
+                  actions: <BottomSheetAction>[
+                    BottomSheetAction(title: 'Item 1', onPressed: () {}),
+                    BottomSheetAction(title: 'Item 2', onPressed: () {}),
+                    BottomSheetAction(title: 'Item 3', onPressed: () {}),
+                  ],
+                  cancelAction: CancelAction(title: 'Cancel'),
+                );
+              },
+              child: const Text('Show action sheet with custom barrier color'),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/src/bottom_sheet_alert.dart
+++ b/lib/src/bottom_sheet_alert.dart
@@ -10,21 +10,26 @@ Future<T> showAdaptiveActionSheet<T>({
   @required BuildContext context,
   @required List<BottomSheetAction> actions,
   CancelAction cancelAction,
+  Color barrierColor,
+  Color bottomSheetColor,
 }) async {
   assert(context != null);
   assert(actions != null);
-  return _show<T>(context, actions, cancelAction);
+  assert(barrierColor != Colors.transparent, 'The barrier color cannot be transparent.');
+  return _show<T>(context, actions, cancelAction, barrierColor, bottomSheetColor);
 }
 
 Future<T> _show<T>(
   BuildContext context,
   List<BottomSheetAction> actions,
   CancelAction cancelAction,
+  Color barrierColor,
+  Color bottomSheetColor,
 ) {
   if (Platform.isIOS) {
-    return _showCupertinoBottomSheet(context, actions, cancelAction);
+    return _showCupertinoBottomSheet(context, actions, cancelAction, barrierColor, bottomSheetColor);
   } else {
-    return _showMaterialBottomSheet(context, actions, cancelAction);
+    return _showMaterialBottomSheet(context, actions, cancelAction, barrierColor, bottomSheetColor);
   }
 }
 
@@ -32,11 +37,14 @@ Future<T> _showCupertinoBottomSheet<T>(
   BuildContext context,
   List<BottomSheetAction> actions,
   CancelAction cancelAction,
+  Color bottomSheetColor,
+  Color barrierColor,
 ) {
   final _textStyle = Theme.of(context).textTheme.headline6;
   return showModalBottomSheet<T>(
     context: context,
-    backgroundColor: Colors.transparent,
+    backgroundColor: bottomSheetColor ?? Colors.transparent,
+    barrierColor: barrierColor,
     builder: (BuildContext coxt) {
       return CupertinoActionSheet(
         actions: actions.map((action) {
@@ -67,12 +75,16 @@ Future<T> _showMaterialBottomSheet<T>(
   BuildContext context,
   List<BottomSheetAction> actions,
   CancelAction cancelAction,
+  Color barrierColor,
+  Color bottomSheetColor,
 ) {
   final _textStyle = Theme.of(context).textTheme.headline6;
   return showModalBottomSheet<T>(
     context: context,
     elevation: 0,
     isScrollControlled: true,
+    backgroundColor: bottomSheetColor ?? Colors.white,
+    barrierColor: barrierColor,
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.only(
         topLeft: Radius.circular(30),


### PR DESCRIPTION
The following PR adds some customization options. This can also be handy if the user wants to override the values set from the theme. 

- Add option to customize colors via bottomSheetColor and barrierColor.
- Update example showcasing the new option.