### PR TITLE
Add support to title for both Android and iOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -82,6 +82,21 @@ class _MyHomePageState extends State<MyHomePage> {
               },
               child: const Text('Show action sheet with custom barrier color'),
             ),
+            RaisedButton(
+              onPressed: () {
+                showAdaptiveActionSheet(
+                  context: context,
+                  title: const Text('This is the title'),
+                  actions: <BottomSheetAction>[
+                    BottomSheetAction(title: 'Item 1', onPressed: () {}),
+                    BottomSheetAction(title: 'Item 2', onPressed: () {}),
+                    BottomSheetAction(title: 'Item 3', onPressed: () {}),
+                  ],
+                  cancelAction: CancelAction(title: 'Cancel'),
+                );
+              },
+              child: const Text('Show action sheet with title'),
+            ),
           ],
         ),
       ),

--- a/lib/src/bottom_sheet_alert.dart
+++ b/lib/src/bottom_sheet_alert.dart
@@ -8,6 +8,7 @@ import 'cancel_action.dart';
 
 Future<T> showAdaptiveActionSheet<T>({
   @required BuildContext context,
+  Widget title,
   @required List<BottomSheetAction> actions,
   CancelAction cancelAction,
   Color barrierColor,
@@ -16,25 +17,27 @@ Future<T> showAdaptiveActionSheet<T>({
   assert(context != null);
   assert(actions != null);
   assert(barrierColor != Colors.transparent, 'The barrier color cannot be transparent.');
-  return _show<T>(context, actions, cancelAction, barrierColor, bottomSheetColor);
+  return _show<T>(context, title, actions, cancelAction, barrierColor, bottomSheetColor);
 }
 
 Future<T> _show<T>(
   BuildContext context,
+  Widget title,
   List<BottomSheetAction> actions,
   CancelAction cancelAction,
   Color barrierColor,
   Color bottomSheetColor,
 ) {
   if (Platform.isIOS) {
-    return _showCupertinoBottomSheet(context, actions, cancelAction, barrierColor, bottomSheetColor);
+    return _showCupertinoBottomSheet(context, title, actions, cancelAction, barrierColor, bottomSheetColor);
   } else {
-    return _showMaterialBottomSheet(context, actions, cancelAction, barrierColor, bottomSheetColor);
+    return _showMaterialBottomSheet(context, title, actions, cancelAction, barrierColor, bottomSheetColor);
   }
 }
 
 Future<T> _showCupertinoBottomSheet<T>(
   BuildContext context,
+  Widget title,
   List<BottomSheetAction> actions,
   CancelAction cancelAction,
   Color bottomSheetColor,
@@ -47,6 +50,7 @@ Future<T> _showCupertinoBottomSheet<T>(
     barrierColor: barrierColor,
     builder: (BuildContext coxt) {
       return CupertinoActionSheet(
+        title: title,
         actions: actions.map((action) {
           return CupertinoActionSheetAction(
             onPressed: action.onPressed,
@@ -73,6 +77,7 @@ Future<T> _showCupertinoBottomSheet<T>(
 
 Future<T> _showMaterialBottomSheet<T>(
   BuildContext context,
+  Widget title,
   List<BottomSheetAction> actions,
   CancelAction cancelAction,
   Color barrierColor,
@@ -102,6 +107,10 @@ Future<T> _showMaterialBottomSheet<T>(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Center(child: title),
+              ),
               ...actions.map<Widget>((action) {
                 return InkWell(
                   onTap: action.onPressed,


### PR DESCRIPTION
I added a new **optional** title parameter to let people pass a `Widget` that will be displayed as title in the action sheet.

It is a widget rather than a String to give total freedom to customize the title based on the specific needs (this follows the implementation of the `CupertinoActionSheet`.


Example of how this will be used can be found in the example app.