### PR TITLE
Add context to action, so we have the right context if we need it

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,15 +45,15 @@ class _MyHomePageState extends State<MyHomePage> {
                   actions: <BottomSheetAction>[
                     BottomSheetAction(
                       title: const Text('Item 1'),
-                      onPressed: () {},
+                      onPressed: (_) {},
                     ),
                     BottomSheetAction(
                       title: const Text('Item 2'),
-                      onPressed: () {},
+                      onPressed: (_) {},
                     ),
                     BottomSheetAction(
                       title: const Text('Item 3'),
-                      onPressed: () {},
+                      onPressed: (_) {},
                     ),
                   ],
                   cancelAction: CancelAction(title: const Text('Cancel')),
@@ -69,15 +69,15 @@ class _MyHomePageState extends State<MyHomePage> {
                   actions: <BottomSheetAction>[
                     BottomSheetAction(
                       title: const Text('Item 1'),
-                      onPressed: () {},
+                      onPressed: (_) {},
                     ),
                     BottomSheetAction(
                       title: const Text('Item 2'),
-                      onPressed: () {},
+                      onPressed: (_) {},
                     ),
                     BottomSheetAction(
                       title: const Text('Item 3'),
-                      onPressed: () {},
+                      onPressed: (_) {},
                     ),
                   ],
                   cancelAction: CancelAction(title: const Text('Cancel')),
@@ -98,7 +98,7 @@ class _MyHomePageState extends State<MyHomePage> {
                           fontWeight: FontWeight.w500,
                         ),
                       ),
-                      onPressed: () {},
+                      onPressed: (_) {},
                       leading: const Icon(Icons.add, size: 25),
                     ),
                     BottomSheetAction(
@@ -110,7 +110,7 @@ class _MyHomePageState extends State<MyHomePage> {
                           color: Colors.red,
                         ),
                       ),
-                      onPressed: () {},
+                      onPressed: (_) {},
                       leading: const Icon(
                         Icons.delete,
                         size: 25,

--- a/lib/src/bottom_sheet_action.dart
+++ b/lib/src/bottom_sheet_action.dart
@@ -11,7 +11,7 @@ class BottomSheetAction {
   final Widget title;
 
   /// The callback that is called when the action item is tapped. (required)
-  final VoidCallback onPressed;
+  final void Function(BuildContext context) onPressed;
 
   /// A widget to display after the title.
   ///

--- a/lib/src/bottom_sheet_alert.dart
+++ b/lib/src/bottom_sheet_alert.dart
@@ -102,7 +102,7 @@ Future<T?> _showCupertinoBottomSheet<T>(
           return Material(
             color: Colors.transparent,
             child: CupertinoActionSheetAction(
-              onPressed: action.onPressed,
+              onPressed: () => action.onPressed(coxt),
               child: Row(
                 children: [
                   if (action.leading != null) ...[
@@ -193,7 +193,7 @@ Future<T?> _showMaterialBottomSheet<T>(
                 ],
                 ...actions.map<Widget>((action) {
                   return InkWell(
-                    onTap: action.onPressed,
+                    onTap: () => action.onPressed(coxt),
                     child: Padding(
                       padding: const EdgeInsets.all(16.0),
                       child: Row(


### PR DESCRIPTION
To close the action sheet we need the right context to make sure we are using the right one with the Navigator.  Otherwise we can pop the wrong route.