### PR TITLE
remove universal_io

### DIFF
--- a/lib/src/bottom_sheet_alert.dart
+++ b/lib/src/bottom_sheet_alert.dart
@@ -1,6 +1,7 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:universal_io/io.dart';
 
 import 'bottom_sheet_action.dart';
 import 'cancel_action.dart';
@@ -175,6 +176,7 @@ Future<T?> _showMaterialBottomSheet<T>(
   return showModalBottomSheet<T>(
     context: context,
     elevation: 0,
+    clipBehavior: Clip.antiAliasWithSaveLayer,
     isDismissible: isDismissible,
     enableDrag: isDismissible,
     isScrollControlled: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  universal_io: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Removed package "universal_io: ^2.2.2" and fixed inkwell shown behind card in Android (Tested and working on Android & iOS)


Related issue: https://github.com/Daniel-Ioannou/flutter_adaptive_action_sheet/issues/27